### PR TITLE
added trailing slash to shortcut url patter, should prevent catchall …

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     url(r'^report_issues/$', views.report_issues, name="report_issues"),
     url(r'^report_issues/apps/(?P<app_name>.+)/(?P<action_name>.+)/(?P<object_id>.+)$', views.report_issues, name="report_issues"),
     url(r'^accounts/', include('registration.backends.hmac.urls')),
-    url(r'^accounts/profile', views.show_profile, name="profile"),
+    url(r'^accounts/profile/$', views.show_profile, name="profile"),
     url(r'^$', views.splash_if_anon, name="home"),
     url(r'^feed/$', views.feed, name="feed"),
     url(r'^upload_dataset/$', views.upload_dataset, name="upload_dataset"),
@@ -19,6 +19,6 @@ urlpatterns = [
     url(r'^update_tags/$', views.update_profile_tags, name="update_tags"),
     url(r'^apps/(?P<app_name>.+)/(?P<action_name>.+)/(?P<object_id>.+)$', views.app_view_relay, name="app_view_relay"),
     url(forms.tag_aac.get_url_pattern(), forms.tag_aac.ajax_autocomplete_view, name=""),
-    url(r'^create_shortcut$', views.create_shortcut, name="create_shortcut"),
-    url(r'^(?P<shortcut_str>.+)$', views.shortcut, name="shortcut")
+    url(r'^create_shortcut/$', views.create_shortcut, name="create_shortcut"),
+    url(r'^(?P<shortcut_str>.+)/$', views.shortcut, name="shortcut")
 ]


### PR DESCRIPTION
…pattern from stopping trailing slash middleware from working